### PR TITLE
Process -fgpu-rdc

### DIFF
--- a/src/hipBin_spirv.h
+++ b/src/hipBin_spirv.h
@@ -700,7 +700,7 @@ void HipBinSpirv::executeHipCCCmd(vector<string> origArgv) {
   opts.needCXXFLAGS.present = opts.compile.present;
   if (opts.needCXXFLAGS.present && !opts.needCFLAGS.present) {
     CMD += " " + HIPCXXFLAGS;
-    CMD += " -x hip --target=x86_64-linux-gnu";
+    CMD += " -x hip";
   }
 
   opts.needLDFLAGS.present =


### PR DESCRIPTION
This patch is for completing PR CHIP-SPV/chip-spv#377 in CHIP-SPV.

* Extract additional flags needed for `-fgpu-rdc` flags from `HIP_OFFLOAD_RDC_SUPPLEMENT_LINK_OPTIONS` variable in .hipInfo.

* Strip duplicate `--offload` options coming from multiple variables in .hipInfo.

* Remove hard coded `--target` option which causes "clang-offload-bundler: error: Can't find bundle for the host
target" error.