### PR TITLE
Handling spaces in arguments with "-D"

### DIFF
--- a/src/hipBin_spirv.h
+++ b/src/hipBin_spirv.h
@@ -151,23 +151,13 @@ public:
    * @return vector<string>
    */
   vector<string> preprocessArgs(const vector<string> &argv) {
+    vector<string> argvNew;
     string argvStr;
     for (auto arg : argv) {
-      argvStr += " " + arg;
+      argvStr = regex_replace(arg, regex("\\s+"), " ");
+      argvStr = regex_replace(argvStr, regex("\\s-x\\s"), " -x");
+      argvNew.push_back(argvStr);
     }
-
-    // replace all instances of multiple whitespaces with one
-    argvStr = regex_replace(argvStr, regex("\\s+"), " ");
-
-    // convert -x <lang> to -x<lang>
-    argvStr = regex_replace(argvStr, regex("\\s-x\\s"), " -x");
-
-    // convert argvStr back to array by splitting on whitespace
-    vector<string> argvNew;
-    std::istringstream iss(argvStr);
-    for (std::string s; iss >> s;)
-      argvNew.push_back(s);
-
     return argvNew;
   }
 
@@ -187,6 +177,7 @@ public:
       if (arg.length() > 2 && arg.substr(0, 2) == "-D") {
         arg = regex_replace(arg, regex("\""), "\\\"");
         arg = regex_replace(arg, regex("\'"), "\\\'");
+        arg = regex_replace(arg, regex(" "), "\\\ ");
       }
 
       if (arg == "-c") {


### PR DESCRIPTION
This is a proposed fix for https://github.com/CHIP-SPV/chipStar/issues/945 . 

The issue looks like it is that currently one large string is made out of all arguments (https://github.com/CHIP-SPV/HIPCC/blob/30f38d7d15e396079ae1e7318d86208e4b616ab0/src/hipBin_spirv.h#L156) and then they are resplit by spaces (https://github.com/CHIP-SPV/HIPCC/blob/30f38d7d15e396079ae1e7318d86208e4b616ab0/src/hipBin_spirv.h#L168) which causes issues if the arguments themselves have spaces in them (like `-DMACRO=\"H\ H\"`). This instead runs the regex in `preprocessArgs` on each argument separately to avoid having to resplit it. It also re-adds in a `\ ` if there are spaces in the macro arguments in `processArgs`. This is just a suggestion for a solution, there may be something cleaner!